### PR TITLE
Implement Agent.AsTool helper

### DIFF
--- a/pkg/agents.go
+++ b/pkg/agents.go
@@ -1,6 +1,11 @@
 package agents
 
-import "github.com/logkn/agents-go/tools"
+import (
+	"fmt"
+
+	"github.com/logkn/agents-go/internal/runner"
+	"github.com/logkn/agents-go/tools"
+)
 
 // ModelConfig contains configuration details for an LLM model.
 // Model is the identifier of the model to use and BaseUrl is an optional
@@ -21,5 +26,33 @@ type Agent struct {
 	Handoffs     []*Agent
 }
 
-// func (a Agent) AsTool(toolname, description string) tools.Tool {
-// }
+// agentToolArgs represents the parameters required when running an Agent as a
+// tool. The embedded agent field is ignored when generating a JSON schema and
+// when unmarshalling parameters.
+type agentToolArgs struct {
+	// Prompt is the user input passed to the nested agent.
+	Prompt string
+
+	agent Agent `json:"-"`
+}
+
+// Run executes the wrapped agent using the provided prompt and returns the
+// final assistant response content. Errors are returned as strings.
+func (a agentToolArgs) Run() any {
+	resp, err := runner.Run(a.agent, a.Prompt)
+	if err != nil {
+		return fmt.Sprintf("error running agent: %v", err)
+	}
+	return resp.Response().Content
+}
+
+// AsTool exposes the agent as an executable Tool. The returned Tool accepts a
+// single parameter `prompt` which is used as the input for the agent. When the
+// tool is invoked, the agent is run and the final response text is returned.
+func (a Agent) AsTool(toolname, description string) tools.Tool {
+	return tools.Tool{
+		Name:        toolname,
+		Description: description,
+		Args:        agentToolArgs{agent: a},
+	}
+}


### PR DESCRIPTION
## Summary
- add Agent.AsTool method
- allow an Agent to be represented as a Tool that executes the agent on a prompt

## Testing
- `go vet ./...` *(fails: Forbidden module downloads)*
- `go test ./...` *(fails: Forbidden module downloads)*

------
https://chatgpt.com/codex/tasks/task_e_683fc06e25f4832d95682358f12dab9e