### PR TITLE
Add bash and file manipulation tools

### DIFF
--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -1,0 +1,31 @@
+package tools
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+// Bash runs a shell command using bash -c.
+// The output of the command (stdout and stderr) is returned as a string.
+type Bash struct {
+	Command string `json:"command" description:"Command to execute"`
+}
+
+func (b Bash) Run() any {
+	if b.Command == "" {
+		return map[string]any{"error": "command cannot be empty"}
+	}
+	cmd := exec.Command("bash", "-c", b.Command)
+	var out bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return map[string]any{"error": err.Error(), "stderr": stderr.String(), "stdout": out.String()}
+	}
+	if stderr.Len() > 0 {
+		return map[string]any{"stderr": stderr.String(), "stdout": out.String()}
+	}
+	return out.String()
+}

--- a/internal/tools/bash_test.go
+++ b/internal/tools/bash_test.go
@@ -1,0 +1,11 @@
+package tools
+
+import "testing"
+
+func TestBashRun(t *testing.T) {
+	b := Bash{Command: "echo hello"}
+	out := b.Run()
+	if out != "hello\n" {
+		t.Fatalf("unexpected output: %v", out)
+	}
+}

--- a/internal/tools/fileops.go
+++ b/internal/tools/fileops.go
@@ -1,0 +1,67 @@
+package tools
+
+import (
+	"os"
+	"strings"
+)
+
+// ReadFile reads the content of a file and returns it as a string.
+type ReadFile struct {
+	Path string `json:"path" description:"Path to the file"`
+}
+
+func (r ReadFile) Run() any {
+	data, err := os.ReadFile(r.Path)
+	if err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+	return string(data)
+}
+
+// WriteFile writes the given content to a file, replacing any existing content.
+type WriteFile struct {
+	Path    string `json:"path" description:"Path to the file"`
+	Content string `json:"content" description:"Content to write"`
+}
+
+func (w WriteFile) Run() any {
+	err := os.WriteFile(w.Path, []byte(w.Content), 0o644)
+	if err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+	return "ok"
+}
+
+// Replace finds Old in the file at Path and replaces it with New.
+// If All is true, all occurrences are replaced. Otherwise exactly one
+// occurrence must exist or an error is returned.
+type Replace struct {
+	Path string `json:"path" description:"Path to the file"`
+	Old  string `json:"old" description:"Substring to replace"`
+	New  string `json:"new" description:"Replacement text"`
+	All  bool   `json:"all" description:"Replace all occurrences"`
+}
+
+func (r Replace) Run() any {
+	data, err := os.ReadFile(r.Path)
+	if err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+	content := string(data)
+	if r.All {
+		content = strings.ReplaceAll(content, r.Old, r.New)
+	} else {
+		count := strings.Count(content, r.Old)
+		if count == 0 {
+			return map[string]any{"error": "substring not found"}
+		}
+		if count > 1 {
+			return map[string]any{"error": "substring occurs more than once"}
+		}
+		content = strings.Replace(content, r.Old, r.New, 1)
+	}
+	if err := os.WriteFile(r.Path, []byte(content), 0o644); err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+	return "ok"
+}

--- a/internal/tools/fileops_test.go
+++ b/internal/tools/fileops_test.go
@@ -1,0 +1,39 @@
+package tools
+
+import (
+	"os"
+	"testing"
+)
+
+func TestReadWriteReplace(t *testing.T) {
+	tmp, err := os.CreateTemp("", "fileops")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := tmp.Name()
+	tmp.Close()
+	defer os.Remove(path)
+
+	// WriteFile
+	w := WriteFile{Path: path, Content: "foo"}
+	if w.Run() != "ok" {
+		t.Fatalf("write failed")
+	}
+
+	// ReadFile
+	r := ReadFile{Path: path}
+	out := r.Run()
+	if out != "foo" {
+		t.Fatalf("read got %v", out)
+	}
+
+	// Replace
+	rep := Replace{Path: path, Old: "foo", New: "bar", All: false}
+	if rep.Run() != "ok" {
+		t.Fatalf("replace failed")
+	}
+	data, _ := os.ReadFile(path)
+	if string(data) != "bar" {
+		t.Fatalf("replace result %s", data)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `Bash` tool to run shell commands
- add `ReadFile`, `WriteFile`, and `Replace` tools
- test new tools

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841ce99f378832d97d8e9240ceafe69