### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Agents Go
+
+Agents Go is a small framework for building and running LLM powered agents in Go. It provides
+utilities for streaming responses, running tools and handing off between multiple agents. A
+simple terminal user interface is included for interactive use.
+
+## Getting Started
+
+1. **Install dependencies**
+   ```bash
+   go mod download
+   ```
+2. **Run the example TUI**
+   ```bash
+   go run ./cmd
+   ```
+3. **Explore the API**
+   The `pkg` package exposes helper functions to run agents and to wrap an agent as a tool. See
+   `examples/handoff_demo.go` for a more advanced scenario demonstrating agent handoffs.
+
+## Developing
+
+Run the test suite with:
+
+```bash
+make test
+```
+
+This will execute all unit tests under the `internal` packages.
+
+

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,3 +1,5 @@
+// Command agents-tui starts a simple terminal user interface demonstrating how
+// to interact with an Agent.
 package main
 
 import (

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,3 +1,6 @@
+// Package cli implements a simple terminal user interface for interacting with
+// an Agent. It streams assistant responses and renders them using the
+// BubbleTea framework.
 package cli
 
 import (
@@ -377,8 +380,11 @@ func (s AppState) View() string {
 
 // executable
 
+// p holds the running BubbleTea program instance.
 var p *tea.Program
 
+// RunTUI launches an interactive terminal UI for the given Agent. The function
+// blocks until the user exits the interface.
 func RunTUI(agent agents.Agent) {
 	p = tea.NewProgram(initialModel(&agent), tea.WithMouseCellMotion())
 	if _, err := p.Run(); err != nil {
@@ -386,6 +392,9 @@ func RunTUI(agent agents.Agent) {
 	}
 }
 
+// StreamAgent starts an agent run using the provided conversation history and
+// returns the streaming response handle. The caller is responsible for reading
+// from the returned AgentResponse.
 func StreamAgent(agent *agents.Agent, messages []types.Message) *runner.AgentResponse {
 	agentResponse, err := runner.Run(*agent, runner.Input{OfMessages: messages})
 	if err != nil {

--- a/internal/cli/rendering.go
+++ b/internal/cli/rendering.go
@@ -89,6 +89,9 @@ func renderContent(content string, isThinking bool) string {
 	return rendered
 }
 
+// RenderMarkdown converts markdown text into styled terminal output. It also
+// detects `<think>` tags and renders their contents in an italic "thinking"
+// style.
 func RenderMarkdown(text string) string {
 	segments := parseContentSegments(text)
 	if len(segments) == 0 {

--- a/internal/tools/coding.go
+++ b/internal/tools/coding.go
@@ -2,6 +2,7 @@ package tools
 
 import "os"
 
+// pwd is the argument structure for the PwdTool. It has no fields.
 type pwd struct{}
 
 func (p pwd) Run() any {
@@ -12,6 +13,8 @@ func (p pwd) Run() any {
 	return path
 }
 
+// PwdTool exposes the current working directory as a tool callable by an
+// agent.
 var PwdTool = Tool{
 	Name:        "pwd",
 	Description: "Get the current working directory.",

--- a/internal/types/agent.go
+++ b/internal/types/agent.go
@@ -8,12 +8,16 @@ import (
 	"github.com/stoewer/go-strcase"
 )
 
+// Handoff defines an agent-to-agent transition. When a tool with the provided
+// name is invoked the conversation is handed to the referenced Agent.
 type Handoff struct {
 	Agent           *Agent
 	ToolName        string
 	ToolDescription string
 }
 
+// defaultName returns the automatically generated tool name in the form
+// "transfer_to_{agent_name}".
 func (h Handoff) defaultName() string {
 	// "transfer_to_{agent_name}"
 	snakecaseName := strings.ReplaceAll(h.Agent.Name, " ", "_")
@@ -21,6 +25,7 @@ func (h Handoff) defaultName() string {
 	return "transfer_to_" + snakecaseName
 }
 
+// fullname returns either the explicit ToolName or the generated default name.
 func (h Handoff) fullname() string {
 	if h.ToolName != "" {
 		return h.ToolName
@@ -28,10 +33,13 @@ func (h Handoff) fullname() string {
 	return h.defaultName()
 }
 
+// defaultDescription builds a generic description for the handoff tool.
 func (h Handoff) defaultDescription() string {
 	return "Handoff to the " + h.Agent.Name + " agent to handle the request."
 }
 
+// description returns the tool description provided by the user or falls back
+// to the automatically generated one.
 func (h Handoff) description() string {
 	if h.ToolDescription != "" {
 		return h.ToolDescription
@@ -59,6 +67,8 @@ type Agent struct {
 	Logger       *slog.Logger
 }
 
+// HandoffTools converts the configured handoffs into executable tools so they
+// can be exposed to the language model during a run.
 func (a *Agent) HandoffTools() []tools.Tool {
 	handoffTools := make([]tools.Tool, len(a.Handoffs))
 	for i, handoff := range a.Handoffs {

--- a/internal/utils/streaming.go
+++ b/internal/utils/streaming.go
@@ -89,8 +89,9 @@ func isValidTagName(name string) bool {
 	return true
 }
 
-// Yields the same stream, but with XML opening and closing tags
-// grouped as one string part.
+// GroupXML reads a stream of strings and groups any XML tags so that opening
+// and closing tags are emitted as single chunks. This makes it easier to render
+// streamed output without breaking tag boundaries.
 func GroupXML(stream chan string) chan string {
 	output := make(chan string)
 
@@ -147,11 +148,17 @@ func GroupXML(stream chan string) chan string {
 	return output
 }
 
+// Token represents a chunk of streamed text. If IsThinking is true the content
+// originated from inside a `<think>` tag and should be rendered in a special
+// style by consumers.
 type Token struct {
 	Content    string
 	IsThinking bool
 }
 
+// DetectThinking reads a stream of strings and emits Tokens which are annotated
+// with whether the text was inside `<think>` tags. This is useful when streaming
+// assistant responses that mix regular output with "thinking" sections.
 func DetectThinking(stream chan string) chan Token {
 	output := make(chan Token)
 

--- a/internal/utils/testing.go
+++ b/internal/utils/testing.go
@@ -2,6 +2,8 @@ package utils
 
 import "time"
 
+// MockStream emits the provided string one character at a time with the given
+// delay between characters. It is useful for testing streaming behaviour.
 func MockStream(text string, delay time.Duration) chan string {
 	output := make(chan string)
 

--- a/pkg/run.go
+++ b/pkg/run.go
@@ -5,6 +5,9 @@ import (
 	"github.com/logkn/agents-go/internal/types"
 )
 
+// Run executes the specified Agent using the provided user input and returns a
+// streaming response handle. It is a convenience wrapper around
+// runner.Run.
 func Run(agent Agent, input string) (runner.AgentResponse, error) {
 	return runner.Run(types.Agent(agent), runner.Input{OfString: input})
 }


### PR DESCRIPTION
## Summary
- add project README
- document the CLI package and exported helper functions
- add doc comments for streaming utilities and the PwdTool
- describe agent handoffs in types package
- document convenience Run helper

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684dc5824144832d8f2dbc964aa3ac6c